### PR TITLE
fix: change date on hero

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -34,7 +34,7 @@ const { id } = Astro.props;
         class="tagline text-xl font-semibold leading-6 tracking-tight text-cyan-900 sm:w-4/5"
       >
         The annual hackathon for change, taking place at McMaster University
-        from January 13 to 15, 2024.
+        from January 12 to 14, 2024.
       </p>
     </div>
 


### PR DESCRIPTION
closes TECH-61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Chore: Updated event dates in the Hero component. The tagline text displaying the event dates has been adjusted from "January 13 to 15, 2024" to "January 12 to 14, 2024". This change ensures that users receive accurate information about the event timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->