### PR TITLE
feat: add mlh logo

### DIFF
--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -31,6 +31,7 @@ module.exports = {
         list: "off",
         listitem: "off",
         "form-field-multiple-labels": "warn",
+        "unsized-images": "warn",
       },
     },
   },

--- a/src/components/MLH.astro
+++ b/src/components/MLH.astro
@@ -1,0 +1,12 @@
+<a
+  id="mlh-trust-badge"
+  class="fixed right-16 top-0 z-50 block w-24 min-w-min max-w-md md:right-2 md:w-36"
+  href="https://mlh.io/na?utm_source=na-hackathon&utm_medium=TrustBadge&utm_campaign=2024-season&utm_content=blue"
+  target="_blank"
+>
+  <img
+    src="https://s3.amazonaws.com/logged-assets/trust-badge/2024/mlh-trust-badge-2024-blue.svg"
+    alt="Major League Hacking 2024 Hackathon Season"
+    class="w-full"
+  />
+</a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,7 @@ import CarouselWrapper from "../components/CarouselWrapper.astro";
 import FAQ from "../components/FAQ.astro";
 import CountdownAndLinks from "../components/CountdownAndLinks.astro";
 import Footer from "../components/Footer.astro";
+import MLH from "../components/MLH.astro";
 
 // Full Astro Component Syntax:
 // https://docs.astro.build/core-concepts/astro-components/
@@ -27,6 +28,7 @@ import Footer from "../components/Footer.astro";
   <div
     class="bg-[url('/dotted_line_bg_ver2.svg')] bg-[length:auto_98%] bg-[70%_10px] bg-no-repeat md:bg-[url('/dotted_line_bg_ver1.svg')] md:bg-cover md:bg-top"
   >
+    <MLH />
     <WhoAreWe id="WhoAreWe" />
     <Community id="Community" />
     <CarouselWrapper id="Carousel" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the MLH Trust Badge for the 2024 hackathon season on the website.
  - Added a direct link to the MLH website for additional trust verification and information.

- **Documentation**
  - Updated the homepage to include the MLH Trust Badge component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->