### PR TITLE
fix: change dates on hero + add FAQ abt 12th

### DIFF
--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -81,6 +81,11 @@ const questions: Array<{
     answer:
       "Projects are judged by event sponsors and experts from the tech sector. Projects are presented to judges at the exposition and evaluated on multiple factors such as presentation, creativity, practical application, and originality.",
   },
+  {
+    question: "What's happening January 12th?",
+    answer:
+      "Our IN PERSON Hackathon event days are January 13th-14th. Friday the 12th will consist of VIRTUAL Pre Hackathon Events to get you prepped and excited for the main hackathon!! Join us for our Meme Contest & Online Team Match Making, Beginners Guide to Hackathon, A Leetcode Workshop, and end the Night playing games with McMaster Extra Life!",
+  },
 ];
 ---
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -41,7 +41,7 @@ const { id } = Astro.props;
         class="tagline text-xl font-semibold leading-6 tracking-tight text-cyan-900 sm:w-4/5"
       >
         The annual hackathon for change, taking place at McMaster University
-        from January 12 to 14, 2024.
+        from January 13 to 14, 2024.
       </p>
     </div>
 


### PR DESCRIPTION
- closes TECH-88 and TECH-89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated FAQ section with information on pre-hackathon events for January 12th.
  
- **Bug Fixes**
  - Corrected the event dates displayed in the Hero component from "January 12 to 14, 2024" to "January 13 to 14, 2024".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->