### PR TITLE
chore: Title update

### DIFF
--- a/src/components/CarouselWrapper.astro
+++ b/src/components/CarouselWrapper.astro
@@ -21,7 +21,7 @@ const images: ReactImageGalleryItem[] = await Promise.all(
       originalAlt:
         "A wide-angle view of a packed lecture hall with rows of students seated at desks, some with raised hands, engaging with a presenter speaking at the front.",
       description:
-        "With over 500 attendees last year, DeltaHacks 10 is shaping up to be the biggest one yet!",
+        "With over 500 attendees last year, DeltaHacks 11 is shaping up to be the biggest one yet!",
     },
     {
       image: DSC01770,

--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -33,8 +33,8 @@ const questions: Array<{
       "Absolutely nothing! All you need is a personal computer to bring along with you to the event!",
   },
   {
-    question: "Will DeltaHacks 10 be in person or virtual?",
-    answer: "DeltaHacks 10 will be taking place fully in person this year.",
+    question: "Will DeltaHacks 11 be in person or virtual?",
+    answer: "DeltaHacks 11s will be taking place fully in person this year.",
   },
   {
     question: "Will attendees still get awesome swag?",
@@ -49,17 +49,17 @@ const questions: Array<{
   {
     question: "What do I need to participate?",
     answer:
-      "DeltaHacks 10 will be in person. Bring in your laptop, reusable water bottle, and prepare to build some amazing projects!",
+      "DeltaHacks 11 will be in person. Bring in your laptop, reusable water bottle, and prepare to build some amazing projects!",
   },
   {
     question: "Will hardware be provided?",
     answer:
-      "Yes we will have hardware available provided by MLH! Feel free to bring your own hardware if you have the material to include into your hack. ",
+      "Yes, we will have hardware available provided by MLH! Feel free to bring your own hardware if you have the material to include into your hack. ",
   },
   {
     question: "When will hacker applications be released?",
     answer:
-      "Hacker applications will be released in the First week of November. Follow us on socials to stay up to date and find out as soon as applications open.",
+      "Hacker applications will be released around McMaster's Reading Week (). Follow us on socials and join our newsletter to stay up to date and find out as soon as applications open.",
   },
   {
     question: "How big can a team be?",
@@ -82,9 +82,9 @@ const questions: Array<{
       "Projects are judged by event sponsors and experts from the tech sector. Projects are presented to judges at the exposition and evaluated on multiple factors such as presentation, creativity, practical application, and originality.",
   },
   {
-    question: "What's happening January 12th?",
+    question: "What's happening January 10th?",
     answer:
-      "Our IN PERSON Hackathon event days are January 13th-14th. Friday the 12th will consist of VIRTUAL Pre Hackathon Events to get you prepped and excited for the main hackathon!! Join us for our Meme Contest & Online Team Match Making, Beginners Guide to Hackathon, A Leetcode Workshop, and end the Night playing games with McMaster Extra Life!",
+      "Our IN PERSON Hackathon event days are January 11th-12th. Friday the 10th will consist of VIRTUAL Pre Hackathon Events to get you prepped and excited for the main hackathon!!!",
   },
 ];
 ---

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -41,7 +41,7 @@ const { id } = Astro.props;
         class="tagline text-xl font-semibold leading-6 tracking-tight text-cyan-900 sm:w-4/5"
       >
         The annual hackathon for change, taking place at McMaster University
-        from January 13 to 14, 2024.
+        from January 11 to 12, 2024.
       </p>
     </div>
 

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -23,13 +23,13 @@ import "@fontsource/poppins/700.css";
     }
 
     <!-- HTML Meta Tags -->
-    <title>DeltaHacks 10</title>
+    <title>DeltaHacks</title>
     <meta name="description" content="The hackathon for change." />
 
     <!-- Facebook Meta Tags -->
     <meta property="og:url" content="https://deltahacks.com/" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="DeltaHacks 10" />
+    <meta property="og:title" content="DeltaHacks" />
     <meta property="og:description" content="The hackathon for change." />
     <meta property="og:image" content="https://deltahacks.com/meta.png" />
 
@@ -37,7 +37,7 @@ import "@fontsource/poppins/700.css";
     <meta name="twitter:card" content="summary_large_image" />
     <meta property="twitter:domain" content="deltahacks.com" />
     <meta property="twitter:url" content="https://deltahacks.com/" />
-    <meta name="twitter:title" content="DeltaHacks 10" />
+    <meta name="twitter:title" content="DeltaHacks" />
     <meta name="twitter:description" content="The hackathon for change." />
     <meta name="twitter:image" content="https://deltahacks.com/meta.png" />
 


### PR DESCRIPTION
Updating the banner title in the website to say "DeltaHacks" instead of DeltaHacks 10, including for Twitter and Facebook links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated event details to reflect DeltaHacks 11, including dates and participation information.
	- Revised FAQ section to provide accurate information regarding the event format and application release.
	- Modified the hero section to display the new event dates.

- **Bug Fixes**
	- Corrected event date range in the hero section from January 13-14 to January 11-12, 2024.

- **Documentation**
	- Updated meta tags across the website to remove references to DeltaHacks 10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->